### PR TITLE
fix: allow SOAP import downloads

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/SoapMessageBuilder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/SoapMessageBuilder.java
@@ -53,6 +53,7 @@ public class SoapMessageBuilder {
         this.options.setLoadAdditionalNamespaces(this.namespaceMappings);
         this.options.setSavePrettyPrint();
         this.options.setSavePrettyPrintIndent(2);
+        this.options.setCompileDownloadUrls();
 
         // provide prefixes used by the WSDL to keep naming consistency in SoapEnvelope message
         this.prefixToNamespaces = new HashMap();


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/9199

## Description

Allow imports in SOAP wsdl definitions.